### PR TITLE
Added {$SNMP_COMMUNITY} macro

### DIFF
--- a/Templates/SonicWallFirewall.xml
+++ b/Templates/SonicWallFirewall.xml
@@ -31,7 +31,7 @@
                 <item>
                     <name>Current Connections</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.1.3.1.2.0</snmp_oid>
                     <key>sonicCurrentConnections</key>
@@ -70,7 +70,7 @@
                 <item>
                     <name>Current CPU Util</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.1.3.1.3.0</snmp_oid>
                     <key>sonicCurrentCPUUtil</key>
@@ -109,7 +109,7 @@
                 <item>
                     <name>Current RAM Usage</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.1.3.1.4.0</snmp_oid>
                     <key>sonicCurrentRAMUtil</key>
@@ -187,7 +187,7 @@
                 <item>
                     <name>Firmware Version</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.2.1.1.3.0</snmp_oid>
                     <key>SysFirmwareVersion</key>
@@ -226,7 +226,7 @@
                 <item>
                     <name>Sonicwall Model</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.2.1.1.1.0</snmp_oid>
                     <key>SysModel</key>
@@ -265,7 +265,7 @@
                 <item>
                     <name>Sonicwall Serial Number</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.8741.2.1.1.2.0</snmp_oid>
                     <key>SysSerialNumber</key>
@@ -306,7 +306,7 @@
                 <discovery_rule>
                     <name>Interfaces</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>ifDescr</snmp_oid>
                     <key>snmp.discovery</key>
                     <delay>300</delay>
@@ -332,7 +332,7 @@
                         <item_prototype>
                             <name>Data In - {#SNMPVALUE}</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.2.1.2.2.1.10.{#SNMPINDEX}</snmp_oid>
                             <key>ifInOctets.[&quot;{#SNMPINDEX}&quot;]</key>
@@ -371,7 +371,7 @@
                         <item_prototype>
                             <name>Data Out - {#SNMPVALUE}</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.2.1.2.2.1.16.{#SNMPINDEX}</snmp_oid>
                             <key>ifOutOctets.[&quot;{#SNMPINDEX}&quot;]</key>


### PR DESCRIPTION
I've added this macro for the SonicWall template, as not everyone sticks with the default 'public' community string.
