### PR TITLE
No more trailing comma after last item in array

### DIFF
--- a/Scripts/HyperV_Status.ps1
+++ b/Scripts/HyperV_Status.ps1
@@ -13,7 +13,12 @@ if ($QueryName -eq '') {
     write-host
 
     foreach ($objItem in $colItems) {
-        $line =  " { `"{#VMNAME}`":`"" + $objItem.Name + "`" , `"{#VMSTATE}`":`"" + $objItem.State + "`" },"
+        if ($objItem -ne $colItems[-1]) {
+            $line =  " { `"{#VMNAME}`":`"" + $objItem.Name + "`" },"
+            }
+        else {
+            $line =  " { `"{#VMNAME}`":`"" + $objItem.Name + "`" }"
+            }
         write-host $line
     }
 


### PR DESCRIPTION
The original script wrote a comma at the end of each line in the array. The comma after the last item generated an error in Zabbix. The discovery rule showed the status Not supported and the error was "Value should be a JSON object". I've added an if statement to check whether the item is the last item in the array and print the line with or without a trailing comma accordingly.
